### PR TITLE
Config timestamp server

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -5,6 +5,7 @@ openssl:
 codesign:
   password:
   keypath:
+  timestamp:
 gpg:
   password:
   key:

--- a/lib/cert-protector.rb
+++ b/lib/cert-protector.rb
@@ -54,7 +54,7 @@ class CertProtector < Sinatra::Base
   put '/sign/codesign' do
     @password = config['codesign']['password']
     @prompt   = "Password:"
-    run("osslsigncode -askpass -h sha256 -pkcs12 #{config['codesign']['keypath']} -t http://timestamp.verisign.com/scripts/timstamp.dll -in #{infile} -out #{outfile}")
+    run("osslsigncode -askpass -h sha256 -pkcs12 #{config['codesign']['keypath']} -t #{config['codesign']['timestamp']} -in #{infile} -out #{outfile}")
   end
 
   # Runs the command for the associated target and pushes the file back to the requestor


### PR DESCRIPTION
# Description
Timestamp servers may be different depending on the certificate used.  Adding an option to allow setting a unique timestamp server.